### PR TITLE
Fixed an error that prevented starting the next round

### DIFF
--- a/tttweightsystem/lua/weightsystem/sv_init.lua
+++ b/tttweightsystem/lua/weightsystem/sv_init.lua
@@ -91,12 +91,15 @@ function SelectPlayerForTraitor( choices, prev_roles )
 	
 	local lastChance
 	for k,v in pairs(choices) do
+		
+		-- Sets the currently being validated player as the last chance incase no one is valid to be a traitor to return at least one player.
+		lastChance = v
+		
 		-- Check to see if the randomly selected number minus the current players weight is less then 0 it means they win the role.
 		print( v:GetName() .. ": " .. r .. " - " .. v:GetWeight() .. " = " .. r - v:GetWeight())
+
 		if (r - v:GetWeight()) <= 0 then
 		
-			-- Set the last chance player to current player, if it ends up not accepting a player to return it will return the last known person in loop.
-			 lastChance = v
 			if IsValid(v) and ( (not table.HasValue(prev_roles[ROLE_TRAITOR], v)) or ( math.random(1, 3) == 2) ) then
 				return v
 			end

--- a/tttweightsystem/lua/weightsystem/sv_init.lua
+++ b/tttweightsystem/lua/weightsystem/sv_init.lua
@@ -88,26 +88,33 @@ function SelectPlayerForTraitor( choices, prev_roles )
 	local r = math.random(1, totalWeight)
 	print( "Amount to beat: " .. r)
 	
-	
+	local defaultT
 	local lastChance
+	
 	for k,v in pairs(choices) do
 		
-		-- Sets the currently being validated player as the last chance incase no one is valid to be a traitor to return at least one player.
-		lastChance = v
+		-- Sets the currently being validated player as the default T to be returned.
+		defaultT = v
 		
 		-- Check to see if the randomly selected number minus the current players weight is less then 0 it means they win the role.
 		print( v:GetName() .. ": " .. r .. " - " .. v:GetWeight() .. " = " .. r - v:GetWeight())
 
 		if (r - v:GetWeight()) <= 0 then
-		
+			
+			-- Set the last chance player to current player, if it ends up not accepting a player to return it will return the last known person in loop.
+			 lastChance = v
 			if IsValid(v) and ( (not table.HasValue(prev_roles[ROLE_TRAITOR], v)) or ( math.random(1, 3) == 2) ) then
 				return v
 			end
 		end
 		r = r - v:GetWeight()
 	end
-		
-	return lastChance
+	
+	if lastChance ~= nil then
+		return lastChance
+	end
+	
+	return defaultT
 end
 
 


### PR DESCRIPTION
With a high total weight and the random number to beat also being high, there was a chance that in the first round of selecting a possible T, no player could have been selected to be one, since no one was able to fulfill the first validation checkpoint.
`if (r - v:GetWeight()) <= 0 then`
No user could have been returned then and the function returned _lastChance_. But that variable wasn't set and therefore nil.
This would cause an error if the program expects this function to return a player.
`selectedPlayer = SelectPlayerForTraitor( choices, prev_roles )`
`selectedPlayer:SetRole( ROLE_TRAITOR )`

This would cause the following error mentioned in issue#9 
`[ERROR] lua/weightsystem/sv_init.lua:174: attempt to index global 'selectedPlayer' (a nil value)`
`1. SelectRoles - lua/weightsystem/sv_init.lua:174`
`2. unknown - gamemodes/terrortown/gamemode/init.lua:653`

My solution is simple: I added a new variable _defaultT_, which every player is being set to when the loop starts. In case no _lastChance_ is set, the last player, that went through the loop is being selected as the new T. In case _lastChance_ is set, _defaultT_ is ignored and _lastChance_ will be returned, if needed.

