### PR TITLE
Various Updates/Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ If you are planning on using one of the two SQL methods, you will need Mysqloo (
 If you are not using SQL to save (1.2.0), proceed to installation
 
 # Installation
-  * 1. Copy the folder `tttweightsystem` into your addons folder.
-  * 2. Open the file lua/autorun/weightsystem_autorun.lua, at the top of the file there is a variable named **WeightSystem.StorageType**, set this to *mysql*, *sqlite*, or *json* based on your preferred saving method.
-  * 3a. For SQL (MySql & sqlite), complete the installation of MySQLoo, and set up a database on your server, proceed to 4a.
-  * 3b. For JSON, proceed to 4b.
-  * 4a. Run your server once and it will generate a database-template.txt in `garrysmod/data/weightsystem`, copy and rename it to database.txt and edit the settings inside with your database connection info. (keep it in the same folder)
-  * 4b. Run your server and start a round of TTT (Set minplayers to 1), the round will auto-complete and you are all set.
+1. Copy the folder `tttweightsystem` into your addons folder.
+2. Open the file lua/autorun/weightsystem_autorun.lua, at the top of the file there is a variable named **WeightSystem.StorageType**, set this to *mysql*, *sqlite*, or *json* based on your preferred saving method.
+3.
+  -  For SQL (MySql & sqlite), complete the installation of MySQLoo, and set up a database on your server, proceed to 4a.
+  -  For JSON, proceed to 4.
+4. 
+  - For SQL, Run your server once and it will generate a database-template.txt in `garrysmod/data/weightsystem`, copy and rename it to database.txt and edit the settings inside with your database connection info. (keep it in the same folder)
+  - For JSON, Run your server and start a round of TTT (Set minplayers to 1), the round will auto-complete and you are all set.
 
 Once the database settings are configured in the database.txt, restart your server or change maps for it to generate the tables. Once the tables are created, thats it! Go gain some weight!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TTT Weighted Traitor Selection
 ## Version 1.2.0
-## By: Izinga, Updated by Phantom139
+## By: Izinga
 
 # Description
 
@@ -20,7 +20,7 @@ If you are not using SQL to save (1.2.0), proceed to installation
 1. Copy the folder `tttweightsystem` into your addons folder.
 2. Open the file lua/autorun/weightsystem_autorun.lua, at the top of the file there is a variable named **WeightSystem.StorageType**, set this to *mysql*, *sqlite*, or *json* based on your preferred saving method.
 3.
-  -  For SQL (MySql & sqlite), complete the installation of MySQLoo, and set up a database on your server, proceed to 4a.
+  -  For SQL (MySql & sqlite), complete the installation of MySQLoo, and set up a database on your server.
   -  For JSON, proceed to 4.
 4. 
   - For SQL, Run your server once and it will generate a database-template.txt in `garrysmod/data/weightsystem`, copy and rename it to database.txt and edit the settings inside with your database connection info. (keep it in the same folder)
@@ -28,7 +28,7 @@ If you are not using SQL to save (1.2.0), proceed to installation
 
 Once the database settings are configured in the database.txt, restart your server or change maps for it to generate the tables. Once the tables are created, thats it! Go gain some weight!
 
-# Commands
+# Console Commands
 
 **ttt_traitor_chance_command**: Sets the command players can use to see their traitor chance. If ttt_show_traitor_chance is set to 0 this will not work. (default !TC)
 
@@ -42,7 +42,7 @@ Once the database settings are configured in the database.txt, restart your serv
 
 ![Image of fat person](http://puu.sh/ignmA/0ed089cde9.jpg)
 
-# Admin Commands
+# Admin Console Commands
 **ttt_weightlogs**: (just typed into console) This allows admins to view all players weight and their chance to become traitor. Admins are also able to see a count of how many times each player has been a specific role. In the weight menu you can also get the players SteamID and set their weight back to default or set the weight to what ever you want, giving the player a higher chance or lower chance at becoming traitor in next round.
 
 To gives users permission to `ttt_weightlogs` they must be in an allowed group. Any group you want to have access must be added to the `data/weightsystem/groupperms.txt` file which gets generated on first load of the script.
@@ -52,11 +52,15 @@ To gives users permission to `ttt_weightlogs` they must be in an allowed group. 
 # Group Extra Weight
 This feature was requested by a user, with it you have the ability to give certain groups extra weight. For example you can have donators get 1 or 2 extra weight every round to increase their chances of being traitor more often. Like the `database.txt` file a `groupweight-template.txt` will be generated with an example (like below) that you can use. You can also just create the file yourself and name it `groupweight.txt` and make sure it is in `/data/weightsystem/` folder.
 
-As of 1.2.0, you can now also use this system to cap a player's chances of being a traitor when assigned to a group as well.
+As of 1.2.0, you can now also use this system to cap a player's percentage of being a traitor when assigned to a group as well.
 
 ```json
 { "1":{ "MaxWeight":10, "GroupName":"[GroupName]", "MinWeight":0, "cappedWeight":10 }, "2":{ "MaxWeight":10, "GroupName":"[AnotherGroupName]", "MinWeight":5, "cappedWeight": 100 } }
 ```
+
+In the above example, the first entry would grant a random weight gain of 0 to 10 each round, but the player would never be allowed to gain weight allowing them to go above a 10% chance to be a traitor in a round. In the second example, the weight gain is 5 to 10 points, but the player can go up to 100% chance.
+
+If you would like to not have bonus weight gain, set both MinWeight and MaxWeight to 0.
 
 If you do not want to use this feature simply don't have a file named `groupweight.txt` in the `/data/weightsystem/` folder with a proper configuration.
 
@@ -82,3 +86,13 @@ As a note, users who are in a group and receive extra weight will be told they a
   * Added an algorithm to count the number of rounds you have not gotten traitor and exponentially increase weight gain once you pass a threshold.
   * Added round statistics to the beginning of a round.
   * Added the ability to cap the traitor chance percentage of a player based on their assigned group.
+  
+# Contributors
+
+## The following have helped this project with bug fixes and feature additions
+
+  * LaurenceKaye
+  * MinIsMin
+  * janesth
+  * monster010
+  * Phantom139

--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
+# TTT Weighted Traitor Selection
+## Version 1.2.0
+## By: Izinga, Updated by Phantom139
+
 # Description
 
 Weighted Traitor Selection allows players to be fairly selected to become traitors and have more people become traitors rather then not getting traitor 5 maps in a row. The longer you go with out being traitor the higher chance you have at becoming traitor. Now that might sound like you could determine who the traitor is; However the algorithm is non-deterministic, making it practically impossible to deduce the current traitors (with the exception with only 2 people playing)
 
 Once you become traitor, your weight gets reset down to a default weight.
 
+# Prerequisites
+
+Depending on your preferred server saving method, you may need additional libraries installed on your server in order for this to properly function. 
+
+If you are planning on using one of the two SQL methods, you will need Mysqloo (https://github.com/FredyH/MySQLOO)
+
+If you are not using SQL to save (1.2.0), proceed to installation
+
 # Installation
 1. Copy the folder `tttweightsystem` into your addons folder.
-2. Mysqloo (MySql) - system uses database to keep persistent weights for all the players. The weights are persistent across maps so if you have a 90% chance to become traitor next round and the map changes you will still have the 90% chance in the next map (as long as no one joins who has a higher weight), It also deletes any records older than 3 weeks old (to prevent it from getting cluttered)
-3. Run your server once and it will generate a database-template.txt in `garrysmod/data/weightsystem`, copy and rename it to database.txt and edit the settings inside with your database connection info. (keep it in the same folder)
+2. Open the file lua/autorun/weightsystem_autorun.lua, at the top of the file there is a variable named **WeightSystem.StorageType**, set this to *mysql*, *sqlite*, or *json* based on your preferred saving method.
+3a. For SQL (MySql & sqlite), complete the installation of MySQLoo, and set up a database on your server, proceed to 4a.
+3b. For JSON, proceed to 4b.
+4a. Run your server once and it will generate a database-template.txt in `garrysmod/data/weightsystem`, copy and rename it to database.txt and edit the settings inside with your database connection info. (keep it in the same folder)
+4b. Run your server and start a round of TTT (Set minplayers to 1), the round will auto-complete and you are all set.
 
 Once the database settings are configured in the database.txt, restart your server or change maps for it to generate the tables. Once the tables are created, thats it! Go gain some weight!
 
@@ -35,8 +50,10 @@ To gives users permission to `ttt_weightlogs` they must be in an allowed group. 
 # Group Extra Weight
 This feature was requested by a user, with it you have the ability to give certain groups extra weight. For example you can have donators get 1 or 2 extra weight every round to increase their chances of being traitor more often. Like the `database.txt` file a `groupweight-template.txt` will be generated with an example (like below) that you can use. You can also just create the file yourself and name it `groupweight.txt` and make sure it is in `/data/weightsystem/` folder.
 
+As of 1.2.0, you can now also use this system to cap a player's chances of being a traitor when assigned to a group as well.
+
 ```json
-{ "1":{ "MaxWeight":10, "GroupName":"[GroupName]", "MinWeight":0 }, "2":{ "MaxWeight":10, "GroupName":"[AnotherGroupName]", "MinWeight":5 } }
+{ "1":{ "MaxWeight":10, "GroupName":"[GroupName]", "MinWeight":0, "cappedWeight":10 }, "2":{ "MaxWeight":10, "GroupName":"[AnotherGroupName]", "MinWeight":5, "cappedWeight": 100 } }
 ```
 
 If you do not want to use this feature simply don't have a file named `groupweight.txt` in the `/data/weightsystem/` folder with a proper configuration.
@@ -49,4 +66,17 @@ The settings for the `groupweight.txt` are as follows -
 
 **GroupName**: The group you wish for a random amount between MinWeight and MaxWeight to be added.
 
+**cappedWeight**: The highest percentage chance a player in the group is allowed to attain for traitor chance.
+
 As a note, users who are in a group and receive extra weight will be told they are getting extra weight because they are in said group.
+
+# Change Log
+
+## 1.1.0 => 1.2.0
+
+  * Added the ability to store information locally in .json format, set the StorageType to json.
+  * Addressed the bug where players can randomly "lose weight", this was due to the system incorrectly trying to save on the final round of a map during the map change.
+  * Re-did the weight reset algorithm to be a bit more random in nature, this will prevent the issue with groups of players being traitor together frequently.
+  * Added an algorithm to count the number of rounds you have not gotten traitor and exponentially increase weight gain once you pass a threshold.
+  * Added round statistics to the beginning of a round.
+  * Added the ability to cap the traitor chance percentage of a player based on their assigned group.

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ If you are planning on using one of the two SQL methods, you will need Mysqloo (
 If you are not using SQL to save (1.2.0), proceed to installation
 
 # Installation
-1. Copy the folder `tttweightsystem` into your addons folder.
-2. Open the file lua/autorun/weightsystem_autorun.lua, at the top of the file there is a variable named **WeightSystem.StorageType**, set this to *mysql*, *sqlite*, or *json* based on your preferred saving method.
-3a. For SQL (MySql & sqlite), complete the installation of MySQLoo, and set up a database on your server, proceed to 4a.
-3b. For JSON, proceed to 4b.
-4a. Run your server once and it will generate a database-template.txt in `garrysmod/data/weightsystem`, copy and rename it to database.txt and edit the settings inside with your database connection info. (keep it in the same folder)
-4b. Run your server and start a round of TTT (Set minplayers to 1), the round will auto-complete and you are all set.
+  * 1. Copy the folder `tttweightsystem` into your addons folder.
+  * 2. Open the file lua/autorun/weightsystem_autorun.lua, at the top of the file there is a variable named **WeightSystem.StorageType**, set this to *mysql*, *sqlite*, or *json* based on your preferred saving method.
+  * 3a. For SQL (MySql & sqlite), complete the installation of MySQLoo, and set up a database on your server, proceed to 4a.
+  * 3b. For JSON, proceed to 4b.
+  * 4a. Run your server once and it will generate a database-template.txt in `garrysmod/data/weightsystem`, copy and rename it to database.txt and edit the settings inside with your database connection info. (keep it in the same folder)
+  * 4b. Run your server and start a round of TTT (Set minplayers to 1), the round will auto-complete and you are all set.
 
 Once the database settings are configured in the database.txt, restart your server or change maps for it to generate the tables. Once the tables are created, thats it! Go gain some weight!
 

--- a/tttweightsystem/lua/autorun/weightsystem_autorun.lua
+++ b/tttweightsystem/lua/autorun/weightsystem_autorun.lua
@@ -1,10 +1,10 @@
-local version = "1.1.0"
+local version = "1.2.0"
 
 WeightSystem = WeightSystem or {}
 WeightSystem.VERSION = version
 CreateConVar("ttt_traitor_chance_command", "!TC", FCVAR_ARCHIVE, "Command that allows users to see their traitor chance when typing in the command.")
 WeightSystem.TraitorChanceCommand = GetConVarString("ttt_traitor_chance_command")
-WeightSystem.StorageType = "sqlite" --This can be 'mysql' or 'sqlite'
+WeightSystem.StorageType = "json" --This can be 'mysql', 'sqlite', or 'json'
 WeightSystem.TableName = "TTT_WeightSystem"
 
 if SERVER then
@@ -34,6 +34,17 @@ if SERVER then
 		end
 	end
 	
+	-- Phantom139: Added code block for custom "json" storage type
+	if WeightSystem.StorageType == "json" then
+		if file.Exists( "weightsystem/table.json", "DATA") then
+			local dbContent = file.Read("weightsystem/table.json", "DATA")
+			local wTable = util.JSONToTable( dbContent )
+			WeightSystem.table = wTable
+		else
+			WeightSystem.table = {}
+			Message("Could not find table.json file, assuming empty" )
+		end
+	end
 
 		-- Make it so file exists no matter what.
 	if not file.Exists( "weightsystem/groupperms.txt", "DATA") then
@@ -53,8 +64,8 @@ if SERVER then
 	-- Create group weight
 	if not file.Exists( "weightsystem/groupweight-template.txt", "DATA") then
 		local customGroupWeightsTemplate = {
-			{ GroupName = "[GroupName]", MinWeight = 0, MaxWeight = 10 },
-			{ GroupName = "[AnotherGroupName]", MinWeight = 5, MaxWeight = 10 }
+			{ GroupName = "[GroupName]", MinWeight = 0, MaxWeight = 10, cappedWeight = -1 },
+			{ GroupName = "[AnotherGroupName]", MinWeight = 5, MaxWeight = 10, cappedWeight = -1 }
 		}
 		local gwJson = util.TableToJSON( customGroupWeightsTemplate )
 		file.Write( "weightsystem/groupweight-template.txt", gwJson)

--- a/tttweightsystem/lua/weightsystem/cl_init.lua
+++ b/tttweightsystem/lua/weightsystem/cl_init.lua
@@ -137,6 +137,12 @@ local function TryOpenMenu( ply )
 end
 concommand.Add("ttt_weightlogs", TryOpenMenu)
 
+local function TryResetTable( ply)
+	net.Start("WeightSystem_ResetTable")
+	net.SendToServer()
+end
+concommand.Add("ttt_weightreset", TryResetTable)
+
 
 function GetPlayerObjectFromName( plyName )
 	for k, v in pairs(player.GetAll()) do

--- a/tttweightsystem/lua/weightsystem/sh_playerweight.lua
+++ b/tttweightsystem/lua/weightsystem/sh_playerweight.lua
@@ -43,6 +43,11 @@ function PLAYER:GetTraitorCount()
 	return self:GetNWInt("TTTWeightSystem_TraitorCount")
 end
 
+-- Phantom139: Added
+function PLAYER:GetRoundsSinceTraitorCount()
+	return self:GetNWInt("TTTWeightSystem_NonTraitorRoundsCount") 
+end
+
 function SetPlayerFunModeScale( ply )
 	if GetConVar("ttt_weight_system_fun_mode"):GetBool() then
 		local min = 1.2
@@ -90,6 +95,13 @@ function PLAYER:GetTraitorChance()
 end
 
 if SERVER then
+
+	util.AddNetworkString("WeightSystem_ResetTable")
+	net.Receive("WeightSystem_ResetTable", function(len, ply)
+		if(ply:IsAdmin()) then
+			ResetTable()
+		end
+	end)
 
 	util.AddNetworkString("WeightSystem_WeightInfo")
     net.Receive("WeightSystem_WeightInfo", function(len, ply)
@@ -192,4 +204,9 @@ if SERVER then
 	function PLAYER:SetTraitorCount( count )
 		self:SetNWInt("TTTWeightSystem_TraitorCount", count)
 	end
+	
+	-- Phantom139: Added
+	function PLAYER:SetRoundsSinceTraitorCount( count )
+		self:SetNWInt("TTTWeightSystem_NonTraitorRoundsCount", count)
+	end	
 end

--- a/tttweightsystem/lua/weightsystem/sh_weightmanager.lua
+++ b/tttweightsystem/lua/weightsystem/sh_weightmanager.lua
@@ -1,13 +1,22 @@
 include("sh_playerweight.lua")
 
 function DefaultWeight()
-    return math.random(1, 5)
+	local playerCount = 0
+	for k,ply in pairs(player.GetAll()) do
+		if IsValid(ply) and (not ply:IsBot()) then
+			playerCount += 1
+		end
+	end
+
+    return math.random(1, 10) * math.random(1, playerCount / 2)
 end
 
 function UpdatePlayerDbWeights()
     for k,ply in pairs(player.GetAll()) do
-            UpdatePlayerWeight(ply, ply:GetWeight())
+		UpdatePlayerDatabase(ply, ply:GetWeight())
     end
+	
+	SaveTable()
 end
 
 function GetActivePlayersTotalWeight()
@@ -30,6 +39,11 @@ end
 
 -- Tells player their chance to become traitor.
 function TellPlayersTraitorChance(ply)
+	  if GetConVar("ttt_ws_show_round_statistics"):GetBool() then
+		ply:PrintMessage( HUD_PRINTTALK, "Round Statistics: You have played " .. ply:GetRoundsPlayed() .. " round(s). Assigned Roles: Innocent: " .. 
+										  ply:GetInnocentCount() .. ", Traitor: " .. ply:GetTraitorCount() .. ", Detective: " .. ply:GetDetectiveCount() .. 
+										  ". It has been " .. ply:GetRoundsSinceTraitorCount() .. " round(s) since you have been a Traitor.")
+	  end
       if GetConVar("ttt_show_traitor_chance"):GetBool() then
 		ply:PrintMessage( HUD_PRINTTALK, "Your chance to become traitor next round is: " .. GetPlayerTraitorChance( ply ) .. "%" )
       end

--- a/tttweightsystem/lua/weightsystem/sv_database.lua
+++ b/tttweightsystem/lua/weightsystem/sv_database.lua
@@ -11,4 +11,9 @@ if storage == "sqlite" then
 elseif storage == "mysql" then
 	Message("Loading with MySQL")
 	include("sv_database_mysql.lua")
+elseif storage == "json" then
+	Message("Loading with JSON Tables")
+	include("sv_database_json.lua")
+else
+	Message("Unknown storage type " .. storage)
 end

--- a/tttweightsystem/lua/weightsystem/sv_database_json.lua
+++ b/tttweightsystem/lua/weightsystem/sv_database_json.lua
@@ -1,0 +1,89 @@
+if not SERVER then return end
+
+include("sh_weightmanager.lua")
+include("sh_playerweight.lua")
+
+local function Message(msg)
+    print("[TTT WeightSystem JSON] " .. msg .. ".")
+end
+
+function DateTime()
+    return os.date( "%y-%m-%d %H:%M:%S" )
+end
+
+function SaveTable()
+	local tab = util.TableToJSON( WeightSystem.table )
+	file.Write("weightsystem/table.json", tab)
+	Message("JSON Table Saved...")
+end
+
+function ResetTable()
+	Message("Resetting weight table")
+	
+	table.Empty(WeightSystem.table)
+	
+	createWeightTable()
+end
+
+function createWeightTable()
+	if table.IsEmpty(WeightSystem.table) then
+		WeightSystem.table = {}
+	else
+		Message("Weight Table is not Empty...")
+	end
+end
+
+function UpdatePlayerDatabase(ply, weight)
+	local newWeight = weight or ply:GetWeight()
+	local innocent = ply:GetInnocentCount()
+	local traitor = ply:GetTraitorCount()
+	local detective = ply:GetDetectiveCount()
+	local rounds = ply:GetRoundsPlayed()
+	local tRounds = ply:GetRoundsSinceTraitorCount()		
+	if ply:IsPlayer() and not ply:IsBot() then
+		WeightSystem.table[util.SteamIDFrom64(tostring(ply:SteamID64()))] = {
+			Weight = newWeight,
+			InnocentRounds = innocent,
+			TraitorRounds = traitor,
+			DetectiveRounds = detective,
+			RoundsPlayed = rounds,
+			RoundsSinceTraitor = tRounds,
+			LastUpdated = DateTime(),
+		}
+	end
+end
+
+-- Connect database on Initialize
+hook.Add("Initialize", "TTTKS_Initialize", function()
+    createWeightTable()
+end)
+
+-- When player joins check if they have a record already, if not create one and set their default weight.
+hook.Add("PlayerInitialSpawn", "TTTWS_PlayerInitialSpawn", function(ply)
+
+	-- Message(WeightSystem.table)
+
+    if ply:IsPlayer() and not ply:IsBot() then
+		-- Check the table for their record
+		if WeightSystem.table[util.SteamIDFrom64(ply:SteamID64())] then
+			Message("Found table data for " .. ply:GetName())
+			ply:SetWeight( WeightSystem.table[util.SteamIDFrom64(tostring(ply:SteamID64()))]["Weight"] )
+			ply:SetInnocentCount( WeightSystem.table[util.SteamIDFrom64(tostring(ply:SteamID64()))]["InnocentRounds"] )
+			ply:SetTraitorCount( WeightSystem.table[util.SteamIDFrom64(tostring(ply:SteamID64()))]["TraitorRounds"] )
+			ply:SetDetectiveCount( WeightSystem.table[util.SteamIDFrom64(tostring(ply:SteamID64()))]["DetectiveRounds"] )
+			ply:SetRoundsPlayed( WeightSystem.table[util.SteamIDFrom64(tostring(ply:SteamID64()))]["RoundsPlayed"] )
+			ply:SetRoundsSinceTraitorCount( WeightSystem.table[util.SteamIDFrom64(tostring(ply:SteamID64()))]["RoundsSinceTraitor"] )			
+		else
+			Message("No data for " .. ply:GetName())
+			ply:SetWeight( defaultWeight )
+			ply:SetInnocentCount( 0 )
+			ply:SetTraitorCount( 0 )
+			ply:SetDetectiveCount( 0 )
+			ply:SetRoundsPlayed( 0 )
+			ply:SetRoundsSinceTraitorCount( 0 )
+			UpdatePlayerDatabase(ply, defaultWeight)
+		end
+		
+   end
+   
+end)

--- a/tttweightsystem/lua/weightsystem/sv_database_sqlite.lua
+++ b/tttweightsystem/lua/weightsystem/sv_database_sqlite.lua
@@ -11,26 +11,60 @@ function DateTime()
     return os.date( "%y-%m-%d %H:%M:%S" )
 end
 
+function SaveTable()
+	Message("SaveTable() Call ignored, only used in JSON")
+end
+
 function ExecuteQuery(str, callback)
 	callback = callback or function() end
+
+	Message("ExecuteQuery(" .. str ..")")
 
 	local result = sql.Query(str)
 
 	if result then
+		Message("Result: " .. result)
 		callback(result)
 	end
+end
+
+function ResetTable()
+	Message("Resetting weight table")
+	
+	ExecuteQuery("DROP TABLE IF EXISTS " .. WeightSystem.TableName)
+	
+	CheckSQLiteTable()
 end
 
 function CheckSQLiteTable()
     Message("Connected to database")
 	
-	ExecuteQuery("CREATE TABLE IF NOT EXISTS " .. WeightSystem.TableName .. " (Id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT, SteamId BIGINT UNSIGNED NOT NULL, Weight SMALLINT UNSIGNED NOT NULL, LastUpdated DATETIME DEFAULT '" .. DateTime() .. "', PRIMARY KEY (Id))")
+	ExecuteQuery("CREATE TABLE IF NOT EXISTS " .. WeightSystem.TableName .. " (Id SMALLINT UNSIGNED NOT NULL AUTO_INCREMENT, " ..
+				 "SteamId BIGINT UNSIGNED NOT NULL, " ..
+				 "Weight SMALLINT UNSIGNED NOT NULL, " ..
+				 "InnocentRounds SMALLINT UNSIGNED NOT NULL, " ..
+				 "TraitorRounds SMALLINT UNSIGNED NOT NULL, " .. 
+				 "DetectiveRounds SMALLINT UNSIGNED NOT NULL, " .. 
+				 "RoundsPlayed SMALLINT UNSIGNED NOT NULL, " .. 
+				 "RoundsSinceTraitor SMALLINT UNSIGNED NOT NULL, " .. 
+	             "LastUpdated DATETIME DEFAULT '" .. DateTime() .. "', PRIMARY KEY (Id))")
 end
 
-function UpdatePlayerWeight(ply, weight)
+function UpdatePlayerDatabase(ply, weight)
         local newWeight = weight or ply:GetWeight()
+		local innocent = ply:GetInnocentCount()
+		local traitor = ply:GetTraitorCount()
+		local detective = ply:GetDetectiveCount()
+		local rounds = ply:GetRoundsPlayed()
+		local tRounds = ply:GetRoundsSinceTraitorCount()
         if ply:IsPlayer() and not ply:IsBot() then
-            ExecuteQuery("UPDATE " .. WeightSystem.TableName .. " SET Weight = " .. newWeight .. ", LastUpdated = '" .. DateTime() .. "' WHERE steamid = " .. ply:SteamID64())
+            ExecuteQuery("UPDATE " .. WeightSystem.TableName .. " SET Weight = " .. newWeight .. ", " ..
+						 "InnocentRounds = " .. innocent .. ", " ..
+						 "TraitorRounds = " .. traitor .. ", " ..
+						 "DetectiveRounds = " .. detective .. ", " ..
+						 "RoundsPlayed = " .. rounds .. ", " ..
+						 "RoundsSinceTraitor = " .. tRounds .. ", " ..
+						 "LastUpdated = '" .. DateTime() .. "' WHERE steamid = " .. ply:SteamID64())
         end
 end
 
@@ -42,15 +76,28 @@ end)
 -- When player joins check if they have a record already, if not create one and set their default weight.
 hook.Add("PlayerInitialSpawn", "TTTWS_PlayerInitialSpawn", function(ply)
     if ply:IsPlayer() and not ply:IsBot() then
-        ExecuteQuery("SELECT Weight FROM " .. WeightSystem.TableName .. " WHERE SteamId = " .. ply:SteamID64(), function(data)
+        ExecuteQuery("SELECT * FROM " .. WeightSystem.TableName .. " WHERE SteamId = " .. ply:SteamID64(), function(data)
                 if table.Count(data) > 0 then
-                    Message(ply:GetName() .. " exists in database, setting player weight to: " .. data[1].Weight)
+                    Message(ply:GetName() .. " exists in database, setting player weight to: " .. data[1].Weight .. ", Round Data: " ..
+							"(" .. data[1].InnocentRounds .. ", " .. data[1].TraitorRounds .. ", " .. data[1].DetectiveRounds .. ", " ..
+							data[1].RoundsPlayed .. ", " .. data[1].RoundsSinceTraitor .. ")")
                     ply:SetWeight( data[1].Weight )
+					ply:SetInnocentCount( data[1].InnocentRounds )
+					ply:SetTraitorCount( data[1].TraitorRounds )
+					ply:SetDetectiveCount( data[1].DetectiveRounds )
+					ply:SetRoundsPlayed( data[1].RoundsPlayed )
+					ply:SetRoundsSinceTraitorCount( data[1].RoundsSinceTraitor )					
                 else
                     local defaultWeight = DefaultWeight()
                     Message(ply:GetName() .. " does not exist in database, creating user and setting default weight to: " .. defaultWeight)
-                    ExecuteQuery("INSERT INTO " .. WeightSystem.TableName .. " ( SteamId, Weight, LastUpdated ) VALUES ( '" .. ply:SteamID64() .. "', " .. defaultWeight .. ", '" .. DateTime() .. "' )")
+                    ExecuteQuery("INSERT INTO " .. WeightSystem.TableName .. " ( SteamId, Weight, InnocentRounds, TraitorRounds, DetectiveRounds, RoundsPlayed, RoundsSinceTraitor, LastUpdated ) " ..
+								 "VALUES ( '" .. ply:SteamID64() .. "', " .. defaultWeight .. ", 0, 0, 0, 0, 0, '" .. DateTime() .. "' )")
                     ply:SetWeight( defaultWeight )
+					ply:SetInnocentCount( 0 )
+					ply:SetTraitorCount( 0 )
+					ply:SetDetectiveCount( 0 )
+					ply:SetRoundsPlayed( 0 )
+					ply:SetRoundsSinceTraitorCount( 0 )
                 end
         end)
    end

--- a/tttweightsystem/lua/weightsystem/sv_init.lua
+++ b/tttweightsystem/lua/weightsystem/sv_init.lua
@@ -11,6 +11,7 @@ CreateConVar("ttt_karma_increase_weight", "0", FCVAR_ARCHIVE + FCVAR_NOTIFY, "En
 CreateConVar("ttt_karma_increase_weight_threshold", "950", FCVAR_ARCHIVE + FCVAR_NOTIFY, "Minimum karma for giving very little bonus weight to the player. Has a chance to give 0 extra weight. (default 950, based off of default max karma)")
 CreateConVar("ttt_show_traitor_chance", "1", FCVAR_ARCHIVE, "At the beginning of every round it will show the chance of the player being traitor in the next round (default 1)")
 CreateConVar("ttt_weight_system_fun_mode", "0", FCVAR_ARCHIVE + FCVAR_NOTIFY, "Sets the players player model scale to the players weight, physically making them their weight. Would not suggest this to be active on serious games. (Default 0)")
+CreateConVar("ttt_ws_show_round_statistics", "1", FCVAR_ARCHIVE, "At the beginning of every round, it will show the statistics of a player's rounds and role counts (default 1)")
 
 
 function AddWeightForGroups()
@@ -23,8 +24,10 @@ function AddWeightForGroups()
 						local minWeight = WeightSystem.GroupWeight[i].MinWeight
 						local maxWeight = WeightSystem.GroupWeight[i].MaxWeight
 						local weight = math.random(minWeight, maxWeight)
-						v:AddWeight( weight )
-						Message( v:GetName() .. " was given extra weight for being in group: " .. groupName )
+						if not (weight == 0) then
+							v:AddWeight( weight )
+							Message( v:GetName() .. " was given extra weight for being in group: " .. groupName )
+						end
 					end
 				end
 			end
@@ -32,6 +35,23 @@ function AddWeightForGroups()
 	end
 end
 
+function findLowestGroupWeight(v)
+	local lowest = 999999
+	if WeightSystem.GroupWeight ~= nil then
+		for i = 1, #WeightSystem.GroupWeight do
+			if not v:IsSpec() and IsValid(v) then
+				local groupName = WeightSystem.GroupWeight[i].GroupName
+				if v:IsUserGroup( groupName ) then
+					local groupCap = WeightSystem.GroupWeight[i].cappedWeight
+					if groupCap < lowest then
+						lowest = groupCap
+					end
+				end
+			end
+		end
+	end
+	return lowest
+end
 
 math.randomseed( os.time() )
 local function shuffleTable( t )
@@ -48,22 +68,9 @@ end
 hook.Add("TTTBeginRound", "TTTWS_BeginRound", function()
 	-- Set players role count
 	for k,v in pairs(player.GetAll()) do
-		if v:GetRole() == ROLE_INNOCENT then
-			v:SetInnocentCount( v:GetInnocentCount() + 1 )
-		end
-		if v:GetRole() == ROLE_DETECTIVE then
-			v:SetDetectiveCount( v:GetDetectiveCount() + 1 )
-		end
-		if v:GetRole() == ROLE_TRAITOR then
-			v:SetTraitorCount( v:GetTraitorCount() + 1 )
-		end
-		v:SetRoundsPlayed( v:GetRoundsPlayed() + 1)
-		
 		-- Send weight info to all players (Only admins will be able to get right message).
 		SendWeightInfo( v, "WeightSystem_WeightInfoUpdated")
 		TellPlayersTraitorChance( v )
-		
-		UpdatePlayerDbWeights()
 
 		SetFunModeScaleAllPlayers() -- Will only happen if the convar is set.
 	end
@@ -159,101 +166,127 @@ hook.Add( "Initialize", "TTTWS_Initialize", function ()
 				table.insert(prev_roles[r], v)
 
 				table.insert(choices, v)
-			 end
-			 -- Set everyone to innocent.
-			 v:SetRole(ROLE_INNOCENT)
+
+				v:SetRoundsPlayed( v:GetRoundsPlayed() + 1)			
+			end
+			-- Set everyone to innocent.
+			v:SetRole(ROLE_INNOCENT)
 		end
 
-      -- determine how many of each role we want
-      local choice_count = #choices
-      local traitor_count = GetTraitorCount(choice_count)
-      local det_count = GetDetectiveCount(choice_count)
+		-- determine how many of each role we want
+		local choice_count = #choices
+		local traitor_count = GetTraitorCount(choice_count)
+		local det_count = GetDetectiveCount(choice_count)
 
-	  if choice_count == 0 then return end
-	  
-	  print("Choice Count: " .. choice_count)
-	  print("Traitor Count: " .. traitor_count)
-	  print("Detective Count: " .. det_count)
+		if choice_count == 0 then return end
 
-        -- first select traitors
+		print("Choice Count: " .. choice_count)
+		print("Traitor Count: " .. traitor_count)
+		print("Detective Count: " .. det_count)
+
+		-- first select traitors
 		local ts = 0
 		while ts < traitor_count do
 			shuffleTable(choices)
-			 
+
 			selectedPlayer = SelectPlayerForTraitor( choices, prev_roles )
 			selectedPlayer:SetRole( ROLE_TRAITOR )
 			selectedPlayer:SetWeight( DefaultWeight() )
 			table.RemoveByValue( choices, selectedPlayer )
 			ts = ts + 1
+
+			selectedPlayer:SetTraitorCount( selectedPlayer:GetTraitorCount() + 1 )
+			-- Phantom139: Added
+			selectedPlayer:SetRoundsSinceTraitorCount( 0 )			
 		end
 
-      -- now select detectives, explicitly choosing from players who did not get
-      -- traitor, so becoming detective does not mean you lost a chance to be
-      -- traitor
-      local ds = 0
-      local min_karma = GetConVarNumber("ttt_detective_karma_min") or 0
+		-- now select detectives, explicitly choosing from players who did not get
+		-- traitor, so becoming detective does not mean you lost a chance to be
+		-- traitor
+		local ds = 0
+		local min_karma = GetConVarNumber("ttt_detective_karma_min") or 0
 
-      while (ds < det_count) and (#choices >= 1) do
+		while (ds < det_count) and (#choices >= 1) do
 
-         -- sometimes we need all remaining choices to be detective to fill the
-         -- roles up, this happens more often with a lot of detective-deniers
-         if #choices <= (det_count - ds) then
-            for k, pply in pairs(choices) do
-               if IsValid(pply) then
-                  pply:SetRole(ROLE_DETECTIVE)
-               end
-            end
+			-- sometimes we need all remaining choices to be detective to fill the
+			-- roles up, this happens more often with a lot of detective-deniers
+			if #choices <= (det_count - ds) then
+				for k, pply in pairs(choices) do
+					if IsValid(pply) then
+						pply:SetRole(ROLE_DETECTIVE)
+						pply:SetDetectiveCount( pply:GetDetectiveCount() + 1 )
+						pply:SetRoundsSinceTraitorCount( pply:GetRoundsSinceTraitorCount() + 1 )				  
+					end
+				end
 
-            break -- out of while
-         end
+				break -- out of while
+			end
 
-         local pick = math.random(1, #choices)
-	 local pply = choices[pick]
-         
-         -- we are less likely to be a detective unless we were innocent last round
-         if (IsValid(pply) and
-             ((pply:GetBaseKarma() > min_karma and
-              table.HasValue(prev_roles[ROLE_INNOCENT], pply)) or
-              math.random(1,3) == 2)) then
+			local pick = math.random(1, #choices)
+			local pply = choices[pick]
 
-            -- if a player has specified he does not want to be detective, we skip
-            -- him here (he might still get it if we don't have enough
-            -- alternatives)
-            if not pply:GetAvoidDetective() then
-               pply:SetRole(ROLE_DETECTIVE)
-               ds = ds + 1
-            end
+			-- we are less likely to be a detective unless we were innocent last round
+			if (IsValid(pply) and
+				((pply:GetBaseKarma() > min_karma and
+				table.HasValue(prev_roles[ROLE_INNOCENT], pply)) or
+				math.random(1,3) == 2)) then
 
-            table.remove(choices, pick)
-         end
-      end
-	  
+				-- if a player has specified he does not want to be detective, we skip
+				-- him here (he might still get it if we don't have enough
+				-- alternatives)
+				if not pply:GetAvoidDetective() then
+					pply:SetRole(ROLE_DETECTIVE)
+					pply:SetDetectiveCount( pply:GetDetectiveCount() + 1 )
+					pply:SetRoundsSinceTraitorCount( pply:GetRoundsSinceTraitorCount() + 1 )			   
+					ds = ds + 1
+				end
+
+				table.remove(choices, pick)
+			end
+		end
+
 		-- Update all innocent players to have increased weight
 		for k,v in pairs(choices) do
-			if IsValid(v) and (not v:IsSpec()) and v:GetRole() == ROLE_INNOCENT then
+			if IsValid(v) and (not v:IsSpec()) and v:GetRole() == ROLE_INNOCENT then		
+				-- Phantom139: Update the player role stats
+				v:SetInnocentCount( v:GetInnocentCount() + 1 )
+				v:SetRoundsSinceTraitorCount( v:GetRoundsSinceTraitorCount() + 1 )				
 				-- If the players karma is greater then the server threshold add weight to him.
 				if GetConVar("ttt_karma_increase_weight"):GetBool() and v:GetBaseKarma() > GetConVar("ttt_karma_increase_weight_threshold"):GetInt() then
 					local extra = math.random(0, 2)
 					v:AddWeight( extra )
 					print(v:GetName() .. " was given " .. extra .. " extra weight for having good karma.")
 				end
-				-- Give normal amount of weight
-				v:AddWeight( math.random(6, 10) )
+				-- Phantom139: Added this block of code here to restrict players chances if they are in a group to the group's cap.
+				if v:GetTraitorChance() > findLowestGroupWeight(v) then
+					print(v:GetName() .. " is capped by a group restriction, no additional weight granted.")
+				else
+					-- Give normal amount of weight
+					v:AddWeight( math.random(6, 10) )
+					-- Phantom139: Added a block here to add additional weight for "streaks" of not being a traitor.
+					if v:GetRoundsSinceTraitorCount() >= math.random(3, 5) then
+						local bonusWeight = math.floor(math.pow(1.75, v:GetRoundsSinceTraitorCount()))
+						v:AddWeight( bonusWeight )
+						print(v:GetName() .. " was given " .. bonusWeight .. " extra weight for being on a streak of not being the traitor. ( " .. v:GetRoundsSinceTraitorCount() .. " rounds)")
+					end
+				end			
 			end
 		end
-	  
+
 		AddWeightForGroups()
-	  
 
-      -- Update the Database weights.
-      GAMEMODE.LastRole = {}
+		-- Phantom139: Move the update DB statement here to address the bug where the table doesn't save on the last round of a match.
+		UpdatePlayerDbWeights()
+		
+		-- Update the Database weights.
+		GAMEMODE.LastRole = {}
 
-      for _, ply in pairs(player.GetAll()) do
-         -- initialize credit count for everyone based on their role
-         ply:SetDefaultCredits()
+		for _, ply in pairs(player.GetAll()) do
+			-- initialize credit count for everyone based on their role
+			ply:SetDefaultCredits()
 
-         -- store a uid -> role map
-         GAMEMODE.LastRole[ply:UniqueID()] = ply:GetRole()
-      end
-   end -- End of SelectRoles()
+			-- store a uid -> role map
+			GAMEMODE.LastRole[ply:UniqueID()] = ply:GetRole()
+			end
+		end -- End of SelectRoles()
 end)


### PR DESCRIPTION
This is the modified version of your system I use on my server. I've named it version 1.2.0 because of the numerous changes and bugfixes I have applied to my version compared to the one present here. The following key bug fixes were done in my version:

- Addressed the issue where weight could be randomly lost by players when switching maps, this was due to the system trying to save at the end of a round during a map change instead of at the beginning of the round once roles are assigned. (#17)
- Added an additional layer of randomness to the defaultWeight reassignment to address a bug with odd numbers of players being paired with the same traitor partner due to similar weight resets.

And the key features added by these commits:

- Added the ability to store the weight table in JSON format locally over SQL due to some issues with sqlite not properly working on some OS distributions, and the tougher installations of sqloo. For those who are struggling with "resetting weights" on map changes, this will also address those issues.
- The system now saves round statistics to the weight tables as well (Total rounds, rounds as each role). When the console variable _ttt_show_traitor_chance_ is set to 1, the summary statistics of the player will be shown to them at the start of each round. This can be disabled by setting _ttt_ws_show_round_statistics_ to 0.
- Added a means for players who have gone on a streak of rounds without being the traitor to exponentially gain weight with a random chance between 3 and 5 rounds, and then guaranteed after 5 rounds to kick their chances up in the queue.
- Modified the group weight system to allow capping a player's traitor chance percentage if they are members of a specific group. 

I also updated the README.md file a bit to provide a bit more doc on the installation process and a section for future changes and contributor mentions. Feel free to adjust these as you'd like.