### PR TITLE
Fixing startup error

### DIFF
--- a/tttweightsystem/lua/weightsystem/sh_weightmanager.lua
+++ b/tttweightsystem/lua/weightsystem/sh_weightmanager.lua
@@ -4,7 +4,7 @@ function DefaultWeight()
 	local playerCount = 0
 	for k,ply in pairs(player.GetAll()) do
 		if IsValid(ply) and (not ply:IsBot()) then
-			playerCount += 1
+			playerCount = playerCount + 1
 		end
 	end
 


### PR DESCRIPTION
[ERROR] addons/tttweightsystem/lua/weightsystem/sh_weightmanager.lua:7: '=' expected near '+'
  1. unknown - addons/tttweightsystem/lua/weightsystem/sv_init.lua:6
   2. include - [C]:-1
    3. unknown - addons/tttweightsystem/lua/autorun/weightsystem_autorun.lua:83


Pull request for https://github.com/lzinga/TTTWeightedTraitorSelection/issues/23